### PR TITLE
Release 1.3.0 — atomic transactions on a single pinned connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.3.0] - 2026-07-05
+### 🐛 Bug Fixes (transaction atomicity)
+- **`runTransaction` is now atomic.** Previously `START TRANSACTION`, the statements, and `COMMIT`/`ROLLBACK` each ran through a freshly acquired/released pool connection, so a transaction's statements scattered across different connections in autocommit mode — atomicity held only by luck (sequential reuse of the same idle connection) and broke under `runTransactionsWithConcurrency`, with rollback running on an unrelated connection. Transactions now acquire **one** connection and run all statements plus BEGIN/COMMIT/ROLLBACK on it. **PostgreSQL transactional DDL rollback now actually works.**
+- **Transaction-level retry.** Transient errors (deadlock/serialization) now retry the whole transaction rather than a single statement (which can't succeed once the transaction is aborted). DDL-containing batches run exactly once, since MySQL implicitly commits before DDL and re-running would double-apply non-idempotent DML in mixed batches.
+
+### ⚠️ Behavior change
+- `startTransaction` / `commit` / `rollback` now require a pinned connection argument and throw otherwise (previously they were silent no-ops against throwaway connections). Use `runTransaction` for atomic multi-statement work.
+
+---
+
 ## [1.2.0] - 2026-07-05
 ### 🔒 Security
 - **SQL identifier escaping.** All interpolated identifiers (table/column/schema/index/constraint names, which originate from arbitrary JSON keys and `metaData`) are now quote-escaped at generation time, and type tokens/lengths are validated. Closes DDL/DML injection via crafted column names. Output is byte-identical for well-formed identifiers.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autosql",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "An auto-parser of JSON into SQL.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -61,7 +61,14 @@ export abstract class Database {
 
     public abstract establishDatabaseConnection(): Promise<void>;
     public abstract testQuery(queryOrParams: QueryInput): Promise<any>;
-    protected abstract executeQuery(queryOrParams: QueryInput): Promise<any>;
+    // When `client` is provided the query runs on that pinned connection and the connection is
+    // NOT released here (the transaction owner manages its lifecycle). Without a client, a
+    // throwaway pool connection is acquired and released per call (standalone queries).
+    protected abstract executeQuery(queryOrParams: QueryInput, client?: any): Promise<any>;
+    // Acquire/release a single pooled connection so a transaction can run all of its
+    // statements (START/…/COMMIT/ROLLBACK) on the same connection.
+    protected abstract acquireConnection(): Promise<any>;
+    protected abstract releaseConnection(client: any): void;
 
     public async establishConnection(): Promise<void> {
         let attempts = 0;
@@ -166,19 +173,22 @@ export abstract class Database {
     }
     
 
-    // Begin transaction.
-    public async startTransaction(): Promise<void> {
-        await this.executeQuery("START TRANSACTION;");
+    // Transaction control statements. These require a pinned connection (see runTransaction);
+    // a transaction spread across throwaway pool connections is not atomic. Call runTransaction
+    // for atomic multi-statement work rather than these directly.
+    public async startTransaction(client: any): Promise<void> {
+        if (!client) throw new Error("startTransaction requires a pinned connection; use runTransaction() for atomic transactions.");
+        await this.executeQuery("START TRANSACTION;", client);
     }
 
-    // Commit transaction.
-    public async commit(): Promise<void> {
-        await this.executeQuery("COMMIT;");
+    public async commit(client: any): Promise<void> {
+        if (!client) throw new Error("commit requires a pinned connection; use runTransaction().");
+        await this.executeQuery("COMMIT;", client);
     }
 
-    // Rollback transaction.
-    public async rollback(): Promise<void> {
-        await this.executeQuery("ROLLBACK;");
+    public async rollback(client: any): Promise<void> {
+        if (!client) throw new Error("rollback requires a pinned connection; use runTransaction().");
+        await this.executeQuery("ROLLBACK;", client);
     }
 
     public async closeConnection(): Promise<{ success: boolean; error?: string }> {
@@ -254,75 +264,74 @@ export abstract class Database {
         if (!this.connection) {
             await this.establishConnection();
         }
-        let results: any[] = [];
-        const maxAttempts = maxQueryAttempts || 3;
-        let _error: any;
         const start = new Date();
         let end: Date;
-        let totalAffectedRows = 0;
-    
+        let _error: any;
+
         // Convert string queries into QueryInput
         const queries = queriesOrStrings.map(query =>
             typeof query === "string" ? { query, params: [] } : query
         );
-    
-        try {
-            await this.startTransaction();
-    
-            for (const QueryInput of queries) {
-                if (!QueryInput?.query?.trim()) continue; // Skip empty queries
-                let attempts = 0;
-                while (attempts < maxAttempts) {
-                    try {
-                        const { rows, affectedRows } = await this.executeQuery(QueryInput);
 
-                        results = results.concat(rows);
-                        totalAffectedRows += affectedRows || 0;
+        // Retry the whole transaction (not individual statements) on transient errors: a
+        // deadlock/serialization failure aborts the entire transaction, so a per-statement
+        // retry on the same connection cannot succeed. Transactions that contain DDL run
+        // exactly once — MySQL implicitly commits before each DDL statement, so re-running a
+        // mixed DDL+DML batch would re-apply the already-committed (non-idempotent) DML.
+        const containsDDL = queries.some(q => /^\s*(create|alter|drop|truncate|rename)\b/i.test(q.query || ""));
+        const maxAttempts = containsDDL ? 1 : (maxQueryAttempts || 3);
 
-                        break; // Exit retry loop on success
-                    } catch (error: any) {
-                        attempts++;
-    
-                        const permanentErrors = await this.getPermanentErrors();
-                        if (permanentErrors.includes(error.code)) {
-                            throw error; // Stop retrying for permanent errors
-                        }
-    
-                        if (attempts >= maxAttempts) {
-                            _error = error;
-                        } else {
-                            await new Promise(res => setTimeout(res, 1000)); // Wait before retry
-                        }
-                    }
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            const client = await this.acquireConnection();
+            let results: any[] = [];
+            let totalAffectedRows = 0;
+            try {
+                await this.startTransaction(client);
+
+                for (const QueryInput of queries) {
+                    if (!QueryInput?.query?.trim()) continue; // Skip empty queries
+                    const { rows, affectedRows } = await this.executeQuery(QueryInput, client);
+                    results = results.concat(rows);
+                    totalAffectedRows += affectedRows || 0;
                 }
-    
-                if (_error) {
-                    throw _error;
+
+                await this.commit(client);
+                end = new Date();
+                return {
+                    start,
+                    end,
+                    duration: end.getTime() - start.getTime(),
+                    affectedRows: totalAffectedRows || results.length,
+                    success: true,
+                    results
+                };
+            } catch (error: any) {
+                this.error(`Transaction error (attempt ${attempt}/${maxAttempts}): ${error}`);
+                try {
+                    await this.rollback(client);
+                } catch (rollbackError) {
+                    this.error(`Rollback failed: ${rollbackError}`);
                 }
+
+                const permanentErrors = await this.getPermanentErrors();
+                if (permanentErrors.includes(error.code) || attempt >= maxAttempts) {
+                    _error = error;
+                    break;
+                }
+                await new Promise(res => setTimeout(res, 1000)); // Wait before retrying the whole transaction
+            } finally {
+                this.releaseConnection(client);
             }
-    
-            await this.commit();
-            end = new Date();
-            return {
-                start,
-                end,
-                duration: end.getTime() - start.getTime(),
-                affectedRows: totalAffectedRows || results.length,
-                success: true,
-                results
-            };
-        } catch (error: any) {
-            this.error(`Transaction error: ${error}`);
-            await this.rollback();
-            end = new Date();
-            return {
-                start,
-                end,
-                duration: end.getTime() - start.getTime(),
-                success: false,
-                error: error.message
-            };
         }
+
+        end = new Date();
+        return {
+            start,
+            end,
+            duration: end.getTime() - start.getTime(),
+            success: false,
+            error: _error?.message
+        };
     }
 
     public async runTransactionsWithConcurrency(queryGroups: QueryInput[][]): Promise<QueryResult[]> {

--- a/src/db/mysql.ts
+++ b/src/db/mysql.ts
@@ -115,21 +115,33 @@ export class MySQLDatabase extends Database {
         }
     }
 
-    protected async executeQuery(query: string): Promise<any>;
-    protected async executeQuery(QueryInput: QueryInput): Promise<any>;
-    protected async executeQuery(queryOrParams: QueryInput): Promise<{ rows: any[]; affectedRows: number }> {
+    protected async acquireConnection(): Promise<PoolConnection> {
         if (!this.connection) {
             await this.establishConnection();
         }
-    
-        let client: PoolConnection | null = null;
+        return await (this.connection as Pool).getConnection();
+    }
+
+    protected releaseConnection(client: PoolConnection): void {
+        if (client) client.release();
+    }
+
+    protected async executeQuery(query: string, client?: PoolConnection): Promise<any>;
+    protected async executeQuery(QueryInput: QueryInput, client?: PoolConnection): Promise<any>;
+    protected async executeQuery(queryOrParams: QueryInput, client?: PoolConnection): Promise<{ rows: any[]; affectedRows: number }> {
+        if (!this.connection) {
+            await this.establishConnection();
+        }
+
+        const pinned = !!client;
+        let conn: PoolConnection | null = client ?? null;
         const query = typeof queryOrParams === "string" ? queryOrParams : queryOrParams.query;
         const params = typeof queryOrParams === "string" ? [] : queryOrParams.params || [];
-    
+
         try {
-            client = await (this.connection as Pool).getConnection();
-            const [rowsOrResult, maybeHeader] = await client.query(query, params) as [any, ResultSetHeader | FieldPacket[]];
-    
+            if (!conn) conn = await (this.connection as Pool).getConnection();
+            const [rowsOrResult, maybeHeader] = await conn.query(query, params) as [any, ResultSetHeader | FieldPacket[]];
+
             const rows = Array.isArray(rowsOrResult) ? rowsOrResult : [];
             let affectedRows = 0;
 
@@ -142,15 +154,18 @@ export class MySQLDatabase extends Database {
             } else if (rows.length > 0) {
                 affectedRows = rows.length;
             }
-    
+
             return { rows, affectedRows };
         } catch (error) {
-            if (client) await client.query("ROLLBACK;");
+            // Standalone query: roll back its throwaway connection. Pinned (transaction)
+            // connection: leave the ROLLBACK to runTransaction so the whole transaction aborts
+            // on this same connection.
+            if (!pinned && conn) { try { await conn.query("ROLLBACK;"); } catch { /* autocommit: nothing to roll back */ } }
             throw error;
         } finally {
-            if (client) client.release();
+            if (!pinned && conn) conn.release();
         }
-    }    
+    }
 
     getCreateSchemaQuery(schemaName: string): QueryInput {
         return { query: `CREATE SCHEMA IF NOT EXISTS \`${schemaName}\`;` };

--- a/src/db/pgsql.ts
+++ b/src/db/pgsql.ts
@@ -145,32 +145,47 @@ export class PostgresDatabase extends Database {
         }
     }    
 
-    protected async executeQuery(query: string): Promise<any>;
-    protected async executeQuery(QueryInput: QueryInput): Promise<any>;
-    protected async executeQuery(queryOrParams: QueryInput): Promise<{ rows: any[]; affectedRows: number }> {
+    protected async acquireConnection(): Promise<PoolClient> {
         if (!this.connection) {
             await this.establishConnection();
         }
-    
+        return await (this.connection as Pool).connect();
+    }
+
+    protected releaseConnection(client: PoolClient): void {
+        if (client) client.release();
+    }
+
+    protected async executeQuery(query: string, client?: PoolClient): Promise<any>;
+    protected async executeQuery(QueryInput: QueryInput, client?: PoolClient): Promise<any>;
+    protected async executeQuery(queryOrParams: QueryInput, client?: PoolClient): Promise<{ rows: any[]; affectedRows: number }> {
+        if (!this.connection) {
+            await this.establishConnection();
+        }
+
         const query = typeof queryOrParams === "string" ? queryOrParams : queryOrParams.query;
         const params = typeof queryOrParams === "string" ? [] : queryOrParams.params || [];
-    
-        let client: PoolClient | null = null;
+
+        const pinned = !!client;
+        let conn: PoolClient | null = client ?? null;
         try {
-            client = await (this.connection as Pool).connect();
-            const result = await client.query(query, params);
-    
+            if (!conn) conn = await (this.connection as Pool).connect();
+            const result = await conn.query(query, params);
+
             const rows = result.rows || [];
             const affectedRows = result.rowCount ?? rows.length ?? 0;
-    
+
             return { rows, affectedRows };
         } catch (error) {
-            if (client) await client.query("ROLLBACK;");
+            // Standalone query: roll back its throwaway connection. Pinned (transaction)
+            // connection: leave the ROLLBACK to runTransaction so the whole transaction aborts
+            // on this same connection.
+            if (!pinned && conn) { try { await conn.query("ROLLBACK;"); } catch { /* autocommit: nothing to roll back */ } }
             throw error;
         } finally {
-            if (client) client.release();
+            if (!pinned && conn) conn.release();
         }
-    }    
+    }
 
     getCreateSchemaQuery(schemaName: string): QueryInput {
         return { query: `CREATE SCHEMA IF NOT EXISTS "${schemaName}";`};

--- a/tests/transaction-atomicity.test.ts
+++ b/tests/transaction-atomicity.test.ts
@@ -1,0 +1,75 @@
+import { DB_CONFIG, Database } from "./utils/testConfig";
+import { MetadataHeader } from "../src/config/types";
+
+// Real-DB proof that runTransaction is atomic. These tests fail against the old
+// implementation (BEGIN/DML/COMMIT ran on different pooled connections, so a "rolled back"
+// statement had actually auto-committed on its own connection).
+
+const TABLE = "txn_atomicity_test";
+const META: MetadataHeader = {
+    id: { type: "int", length: 11, primary: true, allowNull: false },
+    name: { type: "varchar", length: 50, allowNull: false },
+};
+
+Object.values(DB_CONFIG).forEach((config) => {
+    const isMysql = config.sqlDialect === "mysql";
+    const schema = config.schema as string;
+    const qi = (n: string) => (isMysql ? `\`${n}\`` : `"${n}"`);
+    const tbl = `${qi(schema)}.${qi(TABLE)}`;
+    const ph = (i: number) => (isMysql ? "?" : `$${i}`);
+    const insertRow = (id: number, name: string) => ({
+        query: `INSERT INTO ${tbl} (${qi("id")}, ${qi("name")}) VALUES (${ph(1)}, ${ph(2)})`,
+        params: [id, name],
+    });
+
+    describe(`Transaction atomicity for ${config.sqlDialect.toUpperCase()}`, () => {
+        let db: Database;
+
+        const rowCount = async (): Promise<number> => {
+            const r = await db.runQuery({ query: `SELECT COUNT(*) AS c FROM ${tbl}`, params: [] });
+            return Number(Object.values(r.results![0])[0]);
+        };
+
+        beforeAll(async () => {
+            db = Database.create(config);
+            await db.establishConnection();
+            await db.runQuery(db.dropTableQuery(TABLE)).catch(() => {});
+            await db.runTransaction(db.createTableQuery(TABLE, META));
+        });
+
+        afterAll(async () => {
+            await db.runQuery(db.dropTableQuery(TABLE)).catch(() => {});
+            await db.closeConnection();
+        });
+
+        beforeEach(async () => {
+            await db.runQuery({ query: `DELETE FROM ${tbl}`, params: [] });
+        });
+
+        test("a committed transaction persists its rows", async () => {
+            const result = await db.runTransaction([insertRow(2, "carol")]);
+            expect(result.success).toBe(true);
+            expect(await rowCount()).toBe(1);
+        });
+
+        test("a failing statement rolls back the whole transaction", async () => {
+            // Second insert violates the primary key; the first insert must NOT survive.
+            const result = await db.runTransaction([insertRow(1, "alice"), insertRow(1, "bob")]);
+            expect(result.success).toBe(false);
+            expect(await rowCount()).toBe(0);
+        });
+
+        if (!isMysql) {
+            test("PostgreSQL: a failing ALTER rolls back a prior ALTER in the same transaction", async () => {
+                const addCol = { query: `ALTER TABLE ${tbl} ADD COLUMN col_new int`, params: [] };
+                const result = await db.runTransaction([addCol, addCol]); // duplicate column → error
+                expect(result.success).toBe(false);
+                const check = await db.runQuery({
+                    query: `SELECT column_name FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 AND column_name = 'col_new'`,
+                    params: [schema, TABLE],
+                });
+                expect(check.results!.length).toBe(0);
+            });
+        }
+    });
+});


### PR DESCRIPTION
Audit remediation, part 2. Fixes the **transaction-atomicity** theme. **Stacked on #7** (base is `fix/audit-remediation`) — review/merge #7 first, then this retargets to `master`.

Bumps **1.2.0 → 1.3.0**.

## The bug
`runTransaction` ran `START TRANSACTION`, each statement, and `COMMIT`/`ROLLBACK` through `executeQuery`, which **acquired and released a fresh pool connection per call**. So a transaction's statements landed on *different* connections in autocommit mode:
- Atomicity held only *by luck* — when the pool happened to hand back the same idle connection in sequential use.
- It broke entirely under `runTransactionsWithConcurrency` (the library's own concurrent path).
- `ROLLBACK` ran on an unrelated connection — a no-op.

## The fix
- Thread an optional pinned `client` through `executeQuery`; without it, standalone queries acquire/release a throwaway connection exactly as before (byte-identical behavior for `runQuery`).
- Add `acquireConnection`/`releaseConnection`. `runTransaction` acquires **one** connection and runs BEGIN/statements/COMMIT/ROLLBACK all on it, releasing in `finally`. **PostgreSQL transactional DDL rollback now actually works** (the `compensatingDDL` pg no-op assumption is finally valid).
- **Whole-transaction retry** on transient errors (a deadlock aborts the entire transaction, so per-statement retry can't succeed). **DDL-containing batches run once** — MySQL implicitly commits before DDL, so re-running a mixed DDL+DML batch would double-apply the non-idempotent DML (e.g. the `USING`-UPDATE + ALTER path).
- `startTransaction`/`commit`/`rollback` now **require a pinned connection** (throw otherwise) so they can't be used as silent no-ops. Nothing called them directly.

## Proof (the actual deliverable)
`tests/transaction-atomicity.test.ts` runs against **live MySQL + Postgres**:
- Committed transaction persists; a failing statement rolls back the whole transaction.
- **PostgreSQL: a failing `ALTER` rolls back a prior `ALTER` in the same transaction.** This test **fails against the old implementation** (verified by stashing the fix — old code committed the first ALTER on its own connection and the retry re-added the column) and passes with the fix.

## ✅ Tests
Full suite green on live MySQL + Postgres: **37 suites / 432 tests**, including the concurrency-heavy `runTransactionsWithConcurrency` paths (no pool-exhaustion regressions — `getPermanentErrors` is a static import, so no transaction ever needs a second connection while holding one).

## Scope / follow-ups
Deliberately **not** in this PR (separate follow-ups): schema-history `LAST_INSERT_ID`-on-wrong-connection (runs via standalone `runQuery`), stream orphan-cleanup dropping a live staging table, and the `updateSchema` global-mutation concurrency hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)