### PR TITLE
Release 1.3.1 — concurrency fixes (schema history, streaming, advisory locks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.3.1] - 2026-07-05
+### 🐛 Bug Fixes (concurrency)
+- **Schema-history record id.** `recordMigrationStart` returned a wrong/zero id, leaving the history row stuck at `pending` and drift detection without a baseline. MySQL read the id from a separate `SELECT LAST_INSERT_ID()` that ran on a different pooled connection (LAST_INSERT_ID is connection-scoped) — it now runs in one connection-pinned transaction. PostgreSQL failed outright with `"inconsistent types deduced for parameter $1"` (schema-history recording was entirely broken on PG) — fixed with an explicit `$1::varchar` cast.
+- **Stream orphan cleanup no longer drops a live stream's staging table.** Concurrent streams to the same table share the `${prefix}${table}__` name pattern the cleanup scans; staging tables of streams open on the same instance are now excluded. (Cross-process concurrency still needs a DB-side liveness marker.)
+- **PostgreSQL advisory-lock key widened to 64-bit** (two int4 keys via sha256, `pg_advisory_lock(int4, int4)`) so distinct table names no longer collide onto the same lock and serialize. Also release any stale lock connection before overwriting the registry entry (prevents a pooled-connection leak) on both dialects.
+
+---
+
 ## [1.3.0] - 2026-07-05
 ### 🐛 Bug Fixes (transaction atomicity)
 - **`runTransaction` is now atomic.** Previously `START TRANSACTION`, the statements, and `COMMIT`/`ROLLBACK` each ran through a freshly acquired/released pool connection, so a transaction's statements scattered across different connections in autocommit mode — atomicity held only by luck (sequential reuse of the same idle connection) and broke under `runTransactionsWithConcurrency`, with rollback running on an unrelated connection. Transactions now acquire **one** connection and run all statements plus BEGIN/COMMIT/ROLLBACK on it. **PostgreSQL transactional DDL rollback now actually works.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autosql",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "An auto-parser of JSON into SQL.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/db/autosql.ts
+++ b/src/db/autosql.ts
@@ -32,9 +32,17 @@ import {
 
 export class AutoSQLHandler {
     private db: Database;
+    // Staging tables of streams that are currently open on this instance. Orphan cleanup must
+    // never drop these — a concurrent stream to the same table would otherwise destroy a live
+    // run's staging data (both share the `${prefix}${table}__` name pattern).
+    private activeStreamStagingTables = new Set<string>();
 
     constructor(dbInstance: MySQLDatabase | PostgresDatabase) {
         this.db = dbInstance;
+    }
+
+    releaseStreamStaging(stagingTable: string): void {
+        this.activeStreamStagingTables.delete(stagingTable);
     }
 
     async autoCreateTable(table: string, newMetaData: MetadataHeader, tableExists?: boolean, runQuery: boolean = true): Promise<QueryResult | QueryInput[]> {
@@ -1035,6 +1043,7 @@ export class AutoSQLHandler {
 
         const runId = generateRunId();
         const stagingTable = buildStreamStagingTableName(table, prefix, runId);
+        this.activeStreamStagingTables.add(stagingTable);
 
         return new AutoSQLStreamHandle(this, this.db, table, stagingTable, schema, primaryKey, originalSchema);
     }
@@ -1054,6 +1063,7 @@ export class AutoSQLHandler {
         for (const row of result.results) {
             const name: string = row.table_name || row.TABLE_NAME;
             if (!isAutosqlStreamTable(name, table, prefix)) continue;
+            if (this.activeStreamStagingTables.has(name)) continue; // live stream on this instance — not an orphan
             this.db.warn(`autoSQLStream: dropping orphaned stream staging table '${name}' from a previous crashed run.`);
             const dropQ = buildDropStreamStagingTableQuery(name, config);
             await this.db.runTransaction([dropQ]).catch(e =>
@@ -1206,6 +1216,7 @@ export class AutoSQLStreamHandle {
                 );
             }
             if (this.schema) this.db.updateSchema(this.originalSchema);
+            this.handler.releaseStreamStaging(this.stagingTable);
         }
     }
 
@@ -1293,5 +1304,6 @@ export class AutoSQLStreamHandle {
             );
         }
         if (this.schema) this.db.updateSchema(this.originalSchema);
+        this.handler.releaseStreamStaging(this.stagingTable);
     }
 }

--- a/src/db/mysql.ts
+++ b/src/db/mysql.ts
@@ -58,9 +58,13 @@ export class MySQLDatabase extends Database {
                     `Another process may be modifying this table's schema. Increase schemaLockTimeout or retry later.`
                 );
             }
+            // Release any stale connection registered for this table before overwriting, so a
+            // leftover entry can't leak a pooled connection.
+            const stale = this.schemaLockConnections.get(table);
+            if (stale && stale !== client) stale.release();
             this.schemaLockConnections.set(table, client);
         } catch (error) {
-            if (client && !this.schemaLockConnections.has(table)) client.release();
+            if (client && this.schemaLockConnections.get(table) !== client) client.release();
             throw error;
         }
     }

--- a/src/db/pgsql.ts
+++ b/src/db/pgsql.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import type { Pool, PoolClient } from "pg";
 import { Database } from "./database";
 import { pgsqlPermanentErrors } from './permanentErrors/pgsql';
@@ -44,18 +45,18 @@ export class PostgresDatabase extends Database {
         return (this.connection as Pool)?.options?.max ?? 5;
     }
 
-    /** djb2 hash → 32-bit signed integer suitable for pg_advisory_lock(bigint) */
-    private getLockKey(table: string): number {
-        let hash = 5381;
-        for (let i = 0; i < table.length; i++) {
-            hash = ((hash << 5) + hash) + table.charCodeAt(i);
-            hash |= 0; // truncate to 32-bit signed int
-        }
-        return hash;
+    /**
+     * Two int4 keys (from sha256) for the pg_advisory_lock(int4, int4) form — a 64-bit lock
+     * space. A single 32-bit djb2 key made distinct tables collide onto the same advisory
+     * lock and serialize against each other.
+     */
+    private getLockKey(table: string): [number, number] {
+        const h = crypto.createHash("sha256").update(`autosql_schema__${table}`).digest();
+        return [h.readInt32BE(0), h.readInt32BE(4)];
     }
 
     public async acquireSchemaLock(table: string, timeoutSeconds: number): Promise<void> {
-        const lockKey = this.getLockKey(table);
+        const [lockKey1, lockKey2] = this.getLockKey(table);
         if (!this.connection) await this.establishConnection();
         let client: PoolClient | undefined;
         try {
@@ -63,7 +64,7 @@ export class PostgresDatabase extends Database {
             const deadline = Date.now() + timeoutSeconds * 1000;
             let acquired = false;
             while (Date.now() < deadline) {
-                const result = await client.query('SELECT pg_try_advisory_lock($1) AS acquired', [lockKey]);
+                const result = await client.query('SELECT pg_try_advisory_lock($1, $2) AS acquired', [lockKey1, lockKey2]);
                 if (result.rows[0]?.acquired === true) {
                     acquired = true;
                     break;
@@ -77,19 +78,23 @@ export class PostgresDatabase extends Database {
                     `Another process may be modifying this table's schema. Increase schemaLockTimeout or retry later.`
                 );
             }
+            // Release any stale connection registered for this table before overwriting, so a
+            // leftover entry can't leak a pooled connection.
+            const stale = this.schemaLockConnections.get(table);
+            if (stale && stale !== client) stale.release();
             this.schemaLockConnections.set(table, client);
         } catch (error) {
-            if (client && !this.schemaLockConnections.has(table)) client.release();
+            if (client && this.schemaLockConnections.get(table) !== client) client.release();
             throw error;
         }
     }
 
     public async releaseSchemaLock(table: string): Promise<void> {
-        const lockKey = this.getLockKey(table);
+        const [lockKey1, lockKey2] = this.getLockKey(table);
         const client = this.schemaLockConnections.get(table);
         if (!client) return;
         try {
-            await client.query('SELECT pg_advisory_unlock($1)', [lockKey]);
+            await client.query('SELECT pg_advisory_unlock($1, $2)', [lockKey1, lockKey2]);
         } finally {
             client.release();
             this.schemaLockConnections.delete(table);

--- a/src/helpers/schemaHistory.ts
+++ b/src/helpers/schemaHistory.ts
@@ -95,25 +95,33 @@ export async function recordMigrationStart(
         query = `INSERT INTO ${tableRef} (table_name, version, status, applied_at, applied_by, previous_schema, changes)
 SELECT ?, COALESCE(MAX(version), 0) + 1, 'pending', ?, ?, ?, ?
 FROM ${tableRef} WHERE table_name = ?`;
-        const result = await db.runQuery({
-            query,
-            params: [
-                table,
-                now.toISOString().slice(0, 19).replace('T', ' '),
-                appliedBy,
-                JSON.stringify(previousSchema),
-                JSON.stringify(changes),
-                table
-            ]
-        });
-        // Return the inserted id via last insert id
-        const idResult = await db.runQuery({ query: 'SELECT LAST_INSERT_ID() AS id', params: [] });
-        return Number(idResult.results?.[0]?.id ?? 0);
+        // Run the INSERT and LAST_INSERT_ID() in one transaction so they share a single
+        // connection — LAST_INSERT_ID() is connection-scoped, so reading it on a separate
+        // pooled connection (as a second runQuery would) returns 0/unrelated, leaving the
+        // history row stuck at 'pending' and drift detection without a baseline.
+        const result = await db.runTransaction([
+            {
+                query,
+                params: [
+                    table,
+                    now.toISOString().slice(0, 19).replace('T', ' '),
+                    appliedBy,
+                    JSON.stringify(previousSchema),
+                    JSON.stringify(changes),
+                    table
+                ]
+            },
+            { query: 'SELECT LAST_INSERT_ID() AS id', params: [] }
+        ]);
+        return Number(result.results?.[0]?.id ?? 0);
     } else {
         const [s, t] = ref.includes('.') ? ref.split('.') : ['', ref];
         const tableRef = s ? `"${s}"."${t}"` : `"${t}"`;
+        // $1 is used both in the SELECT list and the WHERE clause; without an explicit cast
+        // Postgres infers it as text in one place and varchar in the other and rejects the
+        // statement with "inconsistent types deduced for parameter $1".
         query = `INSERT INTO ${tableRef} (table_name, version, status, applied_at, applied_by, previous_schema, changes)
-SELECT $1, COALESCE(MAX(version), 0) + 1, 'pending', $2, $3, $4::jsonb, $5::jsonb
+SELECT $1::varchar, COALESCE(MAX(version), 0) + 1, 'pending', $2, $3, $4::jsonb, $5::jsonb
 FROM ${tableRef} WHERE table_name = $1
 RETURNING id`;
         const result = await db.runQuery({

--- a/tests/advisory-locks.test.ts
+++ b/tests/advisory-locks.test.ts
@@ -1,6 +1,7 @@
 import { SchemaLockTimeoutError } from "../src/errors";
 import { validateConfig } from "../src/helpers/utilities";
 import { DatabaseConfig } from "../src/config/types";
+import { Database } from "../src/db/database";
 
 const BASE_CONFIG: DatabaseConfig = {
     sqlDialect: "mysql",
@@ -91,33 +92,30 @@ describe("validateConfig — advisory lock options", () => {
 // ---------------------------------------------------------------------------
 
 describe("advisory lock key determinism", () => {
-    // djb2 hash used by PostgresDatabase.getLockKey — reproduced here to verify
-    // that the same table name always produces the same 32-bit signed integer.
-    function djb2(str: string): number {
-        let hash = 5381;
-        for (let i = 0; i < str.length; i++) {
-            hash = ((hash << 5) + hash) + str.charCodeAt(i);
-            hash |= 0;
+    // White-box test of PostgresDatabase.getLockKey — a pair of int4 keys derived from sha256
+    // (used with the pg_advisory_lock(int4, int4) 64-bit form). No connection is needed.
+    const pgDb: any = Database.create({ sqlDialect: "pgsql", host: "localhost", user: "u", password: "p", database: "d" });
+    const key = (t: string): [number, number] => pgDb.getLockKey(t);
+
+    test("same table name produces the same key pair", () => {
+        expect(key("users")).toEqual(key("users"));
+    });
+
+    test("different table names produce different key pairs", () => {
+        expect(key("users")).not.toEqual(key("orders"));
+    });
+
+    test("key is a pair of 32-bit signed integers", () => {
+        const pair = key("some_long_table_name_here");
+        expect(pair).toHaveLength(2);
+        for (const k of pair) {
+            expect(Number.isInteger(k)).toBe(true);
+            expect(k).toBeGreaterThanOrEqual(-2147483648);
+            expect(k).toBeLessThanOrEqual(2147483647);
         }
-        return hash;
-    }
-
-    test("same table name produces same key", () => {
-        expect(djb2("users")).toBe(djb2("users"));
-    });
-
-    test("different table names produce different keys", () => {
-        expect(djb2("users")).not.toBe(djb2("orders"));
-    });
-
-    test("key is a 32-bit signed integer", () => {
-        const key = djb2("some_long_table_name_here");
-        expect(Number.isInteger(key)).toBe(true);
-        expect(key).toBeGreaterThanOrEqual(-2147483648);
-        expect(key).toBeLessThanOrEqual(2147483647);
     });
 
     test("empty string produces a consistent key", () => {
-        expect(djb2("")).toBe(djb2(""));
+        expect(key("")).toEqual(key(""));
     });
 });

--- a/tests/schema-history-db.test.ts
+++ b/tests/schema-history-db.test.ts
@@ -1,0 +1,52 @@
+import { DB_CONFIG, Database } from "./utils/testConfig";
+import { bootstrapSchemaHistoryTable, recordMigrationStart, recordMigrationSuccess } from "../src/helpers/schemaHistory";
+import { MetadataHeader } from "../src/config/types";
+
+// Real-DB proof that recordMigrationStart returns a usable id. On MySQL the id came from a
+// separate `SELECT LAST_INSERT_ID()` runQuery that ran on a *different* pooled connection
+// (LAST_INSERT_ID is connection-scoped), so the id could be 0 and the history row was left
+// stuck at 'pending' with no drift baseline. It now runs in one connection-pinned transaction.
+
+const TABLE = "schema_history_id_test";
+const PREV: MetadataHeader = { id: { type: "int" } };
+const NEXT: MetadataHeader = { id: { type: "int" }, name: { type: "varchar", length: 20 } };
+
+Object.values(DB_CONFIG).forEach((config) => {
+    const isMysql = config.sqlDialect === "mysql";
+    const schema = config.schema as string;
+    const qi = (n: string) => (isMysql ? `\`${n}\`` : `"${n}"`);
+    const hist = `${qi(schema)}.${qi("autosql_schema_history")}`;
+    const ph = (i: number) => (isMysql ? "?" : `$${i}`);
+
+    describe(`Schema-history record id for ${config.sqlDialect.toUpperCase()}`, () => {
+        let db: Database;
+
+        const cleanup = () =>
+            db.runQuery({ query: `DELETE FROM ${hist} WHERE ${qi("table_name")} = ${ph(1)}`, params: [TABLE] }).catch(() => {});
+        const statusOf = async (id: number) => {
+            const r = await db.runQuery({ query: `SELECT ${qi("status")} FROM ${hist} WHERE ${qi("id")} = ${ph(1)}`, params: [id] });
+            return r.results?.[0]?.status;
+        };
+
+        beforeAll(async () => {
+            db = Database.create(config);
+            await db.establishConnection();
+            await bootstrapSchemaHistoryTable(db);
+            await cleanup();
+        });
+
+        afterAll(async () => {
+            await cleanup();
+            await db.closeConnection();
+        });
+
+        test("returns a usable id and the row transitions pending -> applied", async () => {
+            const id = await recordMigrationStart(db, TABLE, PREV, { note: "test" });
+            expect(id).toBeGreaterThan(0);
+            expect(await statusOf(id)).toBe("pending");
+
+            await recordMigrationSuccess(db, id, NEXT);
+            expect(await statusOf(id)).toBe("applied");
+        });
+    });
+});

--- a/tests/stream-orphan-cleanup.test.ts
+++ b/tests/stream-orphan-cleanup.test.ts
@@ -1,0 +1,62 @@
+import { AutoSQLHandler } from "../src/db/autosql";
+
+// A concurrent stream to the same table produces a staging table matching the same
+// `${prefix}${table}__` pattern the orphan cleanup scans for. Cleanup must not drop the
+// staging table of a stream that is currently open on this instance.
+
+function makeMockDb(listedTables: string[], dropCalls: string[]) {
+    return {
+        getConfig: () => ({
+            sqlDialect: "mysql" as const,
+            schema: "s",
+            streamingStagingPrefix: "autosql_stream__",
+            keepOrphanedStagingTables: false,
+        }),
+        updateSchema: jest.fn(),
+        runQuery: jest.fn().mockImplementation((q: { query: string }) => {
+            if (q.query === "SELECT 1") return Promise.resolve({ success: true, results: [{ 1: 1 }] });
+            if (q.query.includes("information_schema.tables")) {
+                return Promise.resolve({ success: true, results: listedTables.map((t) => ({ table_name: t })) });
+            }
+            return Promise.resolve({ success: true, results: [] });
+        }),
+        runTransaction: jest.fn().mockImplementation((qs: { query: string }[]) => {
+            dropCalls.push(qs.map((x) => x.query).join(" "));
+            return Promise.resolve({ success: true });
+        }),
+        warn: jest.fn(),
+        error: jest.fn(),
+    } as any;
+}
+
+describe("stream orphan cleanup", () => {
+    test("does not drop the staging table of a live stream on the same instance", async () => {
+        const listedTables: string[] = [];
+        const dropCalls: string[] = [];
+        const db = makeMockDb(listedTables, dropCalls);
+        const handler = new AutoSQLHandler(db);
+
+        // Open a stream — registers its staging table as active.
+        const handle = await handler.openStream("users");
+        const liveName = (handle as any).stagingTable as string;
+
+        // Simulate the DB now listing both the live stream's table and a genuine orphan
+        // (a leftover from a previous crashed run).
+        listedTables.push(liveName, "autosql_stream__users__deadbeef");
+        dropCalls.length = 0;
+
+        await handler._cleanupOrphanedStreamTables("users", "autosql_stream__");
+
+        const dropped = dropCalls.join(" | ");
+        expect(dropped).toContain("deadbeef"); // genuine orphan is dropped
+        expect(dropped).not.toContain(liveName); // live stream's staging is preserved
+
+        // After the stream ends, its table is no longer protected.
+        await handle.abort();
+        dropCalls.length = 0;
+        listedTables.length = 0;
+        listedTables.push(liveName);
+        await handler._cleanupOrphanedStreamTables("users", "autosql_stream__");
+        expect(dropCalls.join(" | ")).toContain(liveName);
+    });
+});

--- a/tests/streaming-schema-history-e2e.test.ts
+++ b/tests/streaming-schema-history-e2e.test.ts
@@ -78,7 +78,13 @@ function defaultRunQuery(q: { query: string; params?: any[] }): Promise<QueryRes
 
 function makeDb(configOverrides: Partial<DatabaseConfig> = {}) {
     const runQuery = jest.fn().mockImplementation(defaultRunQuery);
-    const runTransaction = jest.fn().mockResolvedValue(ok({ affectedRows: 3 }));
+    const runTransaction = jest.fn().mockImplementation((queries: { query: string }[] = []) => {
+        // recordMigrationStart now runs its INSERT + LAST_INSERT_ID() in one transaction.
+        if (queries.some(q => q.query?.includes('LAST_INSERT_ID'))) {
+            return Promise.resolve(ok({ results: [{ id: 42 }] }));
+        }
+        return Promise.resolve(ok({ affectedRows: 3 }));
+    });
 
     return {
         getConfig: () => ({
@@ -357,11 +363,12 @@ describe("end() — schema history integration", () => {
         });
         const handle = makeHandle(handler, db, { stagingCreated: true });
         await handle.end();
-        const qCalls = (db.runQuery as jest.Mock).mock.calls as any[][];
-        const qQueries = qCalls.map((args) => args[0].query as string);
-        // recordMigrationStart issues INSERT INTO autosql_schema_history ... SELECT ...
+        // recordMigrationStart issues INSERT INTO autosql_schema_history ... SELECT ... inside a
+        // single transaction (so the INSERT and LAST_INSERT_ID() share one connection).
+        const txCalls = (db.runTransaction as jest.Mock).mock.calls as any[][];
+        const txQueries = txCalls.flatMap((args) => ((args[0] as { query: string }[]) || []).map((q) => q.query));
         expect(
-            qQueries.some(
+            txQueries.some(
                 (q) => q.includes("INSERT INTO") && q.includes("autosql_schema_history") && q.includes("SELECT")
             )
         ).toBe(true);

--- a/tests/streaming.test.ts
+++ b/tests/streaming.test.ts
@@ -138,6 +138,7 @@ function makeHandler(db: any) {
     return {
         fetchTableMetadata: jest.fn().mockResolvedValue({ currentMetaData: null, tableExists: false }),
         configureTables: jest.fn().mockResolvedValue([OK_RESULT]),
+        releaseStreamStaging: jest.fn(),
     };
 }
 


### PR DESCRIPTION
Audit remediation, part 3 — the contained concurrency/streaming fixes. Bumps **1.3.0 → 1.3.1** (bug fixes).

## Fixes
- **Schema-history record id** — `recordMigrationStart` returned a wrong/zero id, so history rows stayed `pending` and drift detection had no baseline.
  - **MySQL:** read the id from a separate `SELECT LAST_INSERT_ID()` on a *different* pooled connection (connection-scoped) → now one connection-pinned transaction.
  - **Postgres:** failed outright with `"inconsistent types deduced for parameter $1"` — schema-history recording was **entirely broken on PG** (the audit missed this). Fixed with `$1::varchar`.
  - New real-DB round-trip proof (`bootstrap → recordMigrationStart returns a usable id → row transitions pending → applied`) on both dialects.
- **Stream orphan cleanup** no longer drops a *live* concurrent stream's staging table (both share the `${prefix}${table}__` pattern). Streams open on the same instance are tracked and excluded; released on `end()`/`abort()`. Cross-process concurrency still needs a DB-side liveness marker (follow-up).
- **PG advisory-lock key widened to 64-bit** (two int4 keys via sha256) so distinct tables don't collide onto the same lock and serialize; plus a stale-connection release before overwriting the lock registry (prevents a pooled-connection leak) on both dialects.

## ✅ Tests
Full suite green on live MySQL + Postgres: **39 suites / 435 tests**. New: `schema-history-db.test.ts` (real-DB id round trip) and `stream-orphan-cleanup.test.ts` (guard proof).

## Remaining audit item
`updateSchema` global-config mutation race is the last theme — invasive (thread `schema` through the builders instead of mutating instance config); it'll be its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)