### PR TITLE
Release 1.4.0 — per-operation schema isolation (AsyncLocalStorage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.4.0] - 2026-07-05
+### 🐛 Bug Fixes (concurrency)
+- **Per-call schema is now isolated per operation.** Passing a `schema` to `autoSQL`/`autoSQLChunked`/`openStream` previously mutated the shared `Database` config schema and restored it in a `finally`. Concurrent calls with different schemas on one instance raced on that shared field (queries against the wrong schema; the restore could leave the config permanently wrong), and `openStream` held the mutation for the whole stream lifetime. Each schema-scoped operation now runs inside an `AsyncLocalStorage` context and `getConfig()` resolves the schema from it without mutating the instance, so concurrent operations stay isolated.
+
+### ✨ New
+- `Database.runWithSchema(schema, fn)` — run an operation with an effective schema override for its async duration without mutating instance config.
+
+---
+
 ## [1.3.1] - 2026-07-05
 ### 🐛 Bug Fixes (concurrency)
 - **Schema-history record id.** `recordMigrationStart` returned a wrong/zero id, leaving the history row stuck at `pending` and drift detection without a baseline. MySQL read the id from a separate `SELECT LAST_INSERT_ID()` that ran on a different pooled connection (LAST_INSERT_ID is connection-scoped) — it now runs in one connection-pinned transaction. PostgreSQL failed outright with `"inconsistent types deduced for parameter $1"` (schema-history recording was entirely broken on PG) — fixed with an explicit `$1::varchar` cast.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autosql",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "An auto-parser of JSON into SQL.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/db/autosql.ts
+++ b/src/db/autosql.ts
@@ -848,10 +848,8 @@ export class AutoSQLHandler {
     } 
     
     async autoSQL(table: string, data: Record<string, any>[], schema?: string, primaryKey?: string[]): Promise<QueryResult> {
+      return this.db.runWithSchema(schema, async () => {
         const start = new Date();
-        const originalSchema = this.db.getConfig().schema;
-        if (schema) { this.db.updateSchema(schema); }
-
         const config = this.db.getConfig();
         const useSchemaLock = config.useSchemaLock;
         const lockTimeout = config.schemaLockTimeout ?? defaults.schemaLockTimeout;
@@ -920,9 +918,8 @@ export class AutoSQLHandler {
         } catch (error: any) {
             const end = new Date();
             return { start, end, duration: end.getTime() - start.getTime(), affectedRows: 0, success: false, error: error instanceof Error ? error.message : String(error) };
-        } finally {
-            if (schema) { this.db.updateSchema(originalSchema); }
         }
+      });
     }
 
     /**
@@ -946,10 +943,8 @@ export class AutoSQLHandler {
         schema?: string,
         primaryKey?: string[]
     ): Promise<QueryResult> {
+      return this.db.runWithSchema(schema, async () => {
         const start = new Date();
-        const originalSchema = this.db.getConfig().schema;
-        if (schema) this.db.updateSchema(schema);
-
         const useSchemaLock = this.db.getConfig().useSchemaLock;
         const lockTimeout = this.db.getConfig().schemaLockTimeout ?? defaults.schemaLockTimeout;
 
@@ -1013,9 +1008,8 @@ export class AutoSQLHandler {
                 success: false,
                 error: error instanceof Error ? error.message : String(error)
             };
-        } finally {
-            if (schema) this.db.updateSchema(originalSchema);
         }
+      });
     }
 
     async openStream(
@@ -1023,13 +1017,10 @@ export class AutoSQLHandler {
         schema?: string,
         primaryKey?: string[]
     ): Promise<AutoSQLStreamHandle> {
-        const originalSchema = this.db.getConfig().schema;
-        if (schema) this.db.updateSchema(schema);
-
+      return this.db.runWithSchema(schema, async () => {
         // Connectivity check — surfaces auth/connection errors before first write
         const ping = await this.db.runQuery({ query: 'SELECT 1', params: [] });
         if (!ping.success) {
-            if (schema) this.db.updateSchema(originalSchema);
             throw new Error(`openStream: cannot connect to database — ${ping.error}`);
         }
 
@@ -1045,7 +1036,10 @@ export class AutoSQLHandler {
         const stagingTable = buildStreamStagingTableName(table, prefix, runId);
         this.activeStreamStagingTables.add(stagingTable);
 
-        return new AutoSQLStreamHandle(this, this.db, table, stagingTable, schema, primaryKey, originalSchema);
+        // The handle re-establishes this schema context for its own write()/end()/abort()
+        // calls, which run later in separate async invocations.
+        return new AutoSQLStreamHandle(this, this.db, table, stagingTable, schema, primaryKey);
+      });
     }
 
     async _cleanupOrphanedStreamTables(table: string, prefix: string): Promise<void> {
@@ -1080,7 +1074,6 @@ export class AutoSQLStreamHandle {
     private stagingTable: string;
     private schema: string | undefined;
     private primaryKey: string[] | undefined;
-    private originalSchema: string | undefined;
     private columns: string[] | null = null;
     private stagingCreated = false;
     private ended = false;
@@ -1091,8 +1084,7 @@ export class AutoSQLStreamHandle {
         table: string,
         stagingTable: string,
         schema: string | undefined,
-        primaryKey: string[] | undefined,
-        originalSchema: string | undefined
+        primaryKey: string[] | undefined
     ) {
         this.handler = handler;
         this.db = db;
@@ -1100,34 +1092,35 @@ export class AutoSQLStreamHandle {
         this.stagingTable = stagingTable;
         this.schema = schema;
         this.primaryKey = primaryKey;
-        this.originalSchema = originalSchema;
     }
 
     async write(chunk: Record<string, any>[]): Promise<void> {
         if (this.ended) throw new Error(`autoSQLStream: write() called after end()/abort()`);
         if (chunk.length === 0) return;
+        return this.db.runWithSchema(this.schema, async () => {
+            const config = this.db.getConfig();
 
-        const config = this.db.getConfig();
-
-        if (!this.stagingCreated) {
-            // Derive columns from first row
-            this.columns = Object.keys(chunk[0]);
-            const createQ = buildCreateStreamStagingTableQuery(this.stagingTable, this.columns, config);
-            const createResult = await this.db.runTransaction([createQ]);
-            if (!createResult.success) {
-                throw new Error(`autoSQLStream: failed to create stream staging table '${this.stagingTable}': ${createResult.error}`);
+            if (!this.stagingCreated) {
+                // Derive columns from first row
+                this.columns = Object.keys(chunk[0]);
+                const createQ = buildCreateStreamStagingTableQuery(this.stagingTable, this.columns, config);
+                const createResult = await this.db.runTransaction([createQ]);
+                if (!createResult.success) {
+                    throw new Error(`autoSQLStream: failed to create stream staging table '${this.stagingTable}': ${createResult.error}`);
+                }
+                this.stagingCreated = true;
             }
-            this.stagingCreated = true;
-        }
 
-        const insertQ = buildInsertIntoStreamStagingQuery(this.stagingTable, this.columns!, chunk, config);
-        const insertResult = await this.db.runTransaction([insertQ]);
-        if (!insertResult.success) {
-            throw new Error(`autoSQLStream: failed to write chunk to staging table '${this.stagingTable}': ${insertResult.error}`);
-        }
+            const insertQ = buildInsertIntoStreamStagingQuery(this.stagingTable, this.columns!, chunk, config);
+            const insertResult = await this.db.runTransaction([insertQ]);
+            if (!insertResult.success) {
+                throw new Error(`autoSQLStream: failed to write chunk to staging table '${this.stagingTable}': ${insertResult.error}`);
+            }
+        });
     }
 
     async end(): Promise<QueryResult> {
+      return this.db.runWithSchema(this.schema, async () => {
         const start = new Date();
         this.ended = true;
         const config = this.db.getConfig();
@@ -1215,9 +1208,9 @@ export class AutoSQLStreamHandle {
                     this.db.error(`autoSQLStream: failed to drop staging table '${this.stagingTable}': ${e.message}`)
                 );
             }
-            if (this.schema) this.db.updateSchema(this.originalSchema);
             this.handler.releaseStreamStaging(this.stagingTable);
         }
+      });
     }
 
     private async _perRowMerge(
@@ -1297,13 +1290,14 @@ export class AutoSQLStreamHandle {
 
     async abort(): Promise<void> {
         this.ended = true;
-        if (this.stagingCreated) {
-            const dropQ = buildDropStreamStagingTableQuery(this.stagingTable, this.db.getConfig());
-            await this.db.runTransaction([dropQ]).catch(e =>
-                this.db.error(`autoSQLStream: failed to drop staging table during abort: ${e.message}`)
-            );
-        }
-        if (this.schema) this.db.updateSchema(this.originalSchema);
-        this.handler.releaseStreamStaging(this.stagingTable);
+        return this.db.runWithSchema(this.schema, async () => {
+            if (this.stagingCreated) {
+                const dropQ = buildDropStreamStagingTableQuery(this.stagingTable, this.db.getConfig());
+                await this.db.runTransaction([dropQ]).catch(e =>
+                    this.db.error(`autoSQLStream: failed to drop staging table during abort: ${e.message}`)
+                );
+            }
+            this.handler.releaseStreamStaging(this.stagingTable);
+        });
     }
 }

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'async_hooks';
 import { isValidSingleQuery } from './utils/validateQuery';
 import { QueryInput, DatabaseConfig, DialectConfig, ColumnDefinition, AlterTableChanges, InsertResult, MetadataHeader, QueryResult, InsertInput } from '../config/types';
 import { validateConfig, parseDatabaseMetaData } from '../helpers/utilities';
@@ -11,13 +12,30 @@ export abstract class Database {
     protected config: DatabaseConfig;
     public autoSQLHandler!: AutoSQLHandler;
     protected abstract getPermanentErrors(): Promise<string[]>;
+    // Per-operation schema override. A schema-scoped call (e.g. autoSQL(table, data, schema))
+    // runs its whole async operation inside this context so concurrent calls with different
+    // schemas stay isolated instead of racing on a shared, mutated this.config.schema.
+    private schemaContext = new AsyncLocalStorage<string>();
 
     constructor(config: DatabaseConfig) {
         this.config = validateConfig(config);
     }
 
     public getConfig() {
+        const ctxSchema = this.schemaContext.getStore();
+        if (ctxSchema !== undefined) return { ...this.config, schema: ctxSchema };
         return this.config;
+    }
+
+    /**
+     * Run `fn` with `schema` as the effective config schema for the duration of the async
+     * operation (and everything it awaits), without mutating the shared instance config.
+     * Concurrent operations with different schemas do not interfere. A falsy schema runs
+     * `fn` unchanged against the configured schema.
+     */
+    public runWithSchema<T>(schema: string | undefined, fn: () => T): T {
+        if (!schema) return fn();
+        return this.schemaContext.run(schema, fn);
     }
 
     public updateTableMetadata(table: string, metaData: MetadataHeader, type: "metaData" | "existingMetaData" = "metaData"): void {

--- a/tests/chunked-insert.test.ts
+++ b/tests/chunked-insert.test.ts
@@ -49,6 +49,7 @@ async function* makeChunks(chunks: Record<string, any>[][]): AsyncIterable<Recor
 
 function buildMockDb(overrides: Partial<Database> = {}): Database {
     return {
+        runWithSchema: (_s: any, fn: any) => fn(),
         getConfig: () => ({
             sqlDialect: "mysql" as const,
             useWorkers: false,

--- a/tests/schema-context.test.ts
+++ b/tests/schema-context.test.ts
@@ -1,0 +1,44 @@
+import { Database } from "../src/db/database";
+
+// runWithSchema replaces the old updateSchema(this.config.schema) mutation. Concurrent
+// schema-scoped operations on one Database instance must each see their own schema across
+// await points, without corrupting the shared instance config.
+
+describe("per-operation schema context", () => {
+    const makeDb = () =>
+        Database.create({ sqlDialect: "mysql", host: "h", user: "u", password: "p", database: "d", schema: "base" }) as any;
+
+    test("getConfig reflects the configured schema outside any context", () => {
+        const db = makeDb();
+        expect(db.getConfig().schema).toBe("base");
+    });
+
+    test("concurrent contexts with different schemas stay isolated across awaits", async () => {
+        const db = makeDb();
+        const results = await Promise.all([
+            db.runWithSchema("schema_a", async () => {
+                await new Promise((r) => setTimeout(r, 20));
+                return db.getConfig().schema;
+            }),
+            db.runWithSchema("schema_b", async () => {
+                await new Promise((r) => setTimeout(r, 5));
+                return db.getConfig().schema;
+            }),
+        ]);
+        expect(results).toEqual(["schema_a", "schema_b"]);
+    });
+
+    test("the shared instance config is never mutated by a scoped operation", async () => {
+        const db = makeDb();
+        await db.runWithSchema("other", async () => {
+            expect(db.getConfig().schema).toBe("other");
+        });
+        expect(db.getConfig().schema).toBe("base");
+    });
+
+    test("a falsy schema runs against the configured schema", async () => {
+        const db = makeDb();
+        const seen = await db.runWithSchema(undefined, async () => db.getConfig().schema);
+        expect(seen).toBe("base");
+    });
+});

--- a/tests/stream-orphan-cleanup.test.ts
+++ b/tests/stream-orphan-cleanup.test.ts
@@ -6,6 +6,7 @@ import { AutoSQLHandler } from "../src/db/autosql";
 
 function makeMockDb(listedTables: string[], dropCalls: string[]) {
     return {
+        runWithSchema: (_s: any, fn: any) => fn(),
         getConfig: () => ({
             sqlDialect: "mysql" as const,
             schema: "s",

--- a/tests/streaming-schema-history-e2e.test.ts
+++ b/tests/streaming-schema-history-e2e.test.ts
@@ -87,6 +87,7 @@ function makeDb(configOverrides: Partial<DatabaseConfig> = {}) {
     });
 
     return {
+        runWithSchema: (_s: any, fn: any) => fn(),
         getConfig: () => ({
             sqlDialect: "mysql" as const,
             useSchemaLock: false,
@@ -153,7 +154,6 @@ function makeHandle(
         "users",
         "autosql_stream__users__abc12345",
         opts.schema,
-        undefined,
         undefined
     );
     if (opts.stagingCreated) {

--- a/tests/streaming.test.ts
+++ b/tests/streaming.test.ts
@@ -110,6 +110,7 @@ const OK_RESULT = { start: new Date(), end: new Date(), duration: 0, success: tr
 
 function makeDb(configOverrides: Partial<DatabaseConfig> = {}) {
     return {
+        runWithSchema: (_s: any, fn: any) => fn(),
         getConfig: () => ({
             sqlDialect: "mysql" as const,
             useSchemaLock: false,
@@ -146,14 +147,14 @@ describe("AutoSQLStreamHandle", () => {
     test("write() with empty chunk is a no-op", async () => {
         const db = makeDb();
         const handler = makeHandler(db);
-        const handle = new AutoSQLStreamHandle(handler as any, db as any, "users", "autosql_stream__users__abc12345", undefined, undefined, undefined);
+        const handle = new AutoSQLStreamHandle(handler as any, db as any, "users", "autosql_stream__users__abc12345", undefined, undefined);
         await handle.write([]);
         expect(db.runTransaction).not.toHaveBeenCalled();
     });
 
     test("write() after end() throws", async () => {
         const db = makeDb();
-        const handle = new AutoSQLStreamHandle(makeHandler(db) as any, db as any, "users", "autosql_stream__users__abc12345", undefined, undefined, undefined);
+        const handle = new AutoSQLStreamHandle(makeHandler(db) as any, db as any, "users", "autosql_stream__users__abc12345", undefined, undefined);
         // Mark as ended by calling abort
         await handle.abort();
         await expect(handle.write([{ id: 1 }])).rejects.toThrow("write() called after end()/abort()");
@@ -161,7 +162,7 @@ describe("AutoSQLStreamHandle", () => {
 
     test("abort() drops staging table if created", async () => {
         const db = makeDb();
-        const handle = new AutoSQLStreamHandle(makeHandler(db) as any, db as any, "users", "autosql_stream__users__abc12345", undefined, undefined, undefined);
+        const handle = new AutoSQLStreamHandle(makeHandler(db) as any, db as any, "users", "autosql_stream__users__abc12345", undefined, undefined);
         // Simulate staging created
         (handle as any).stagingCreated = true;
         await handle.abort();
@@ -172,7 +173,7 @@ describe("AutoSQLStreamHandle", () => {
 
     test("abort() is a no-op when staging was never created", async () => {
         const db = makeDb();
-        const handle = new AutoSQLStreamHandle(makeHandler(db) as any, db as any, "users", "autosql_stream__users__abc12345", undefined, undefined, undefined);
+        const handle = new AutoSQLStreamHandle(makeHandler(db) as any, db as any, "users", "autosql_stream__users__abc12345", undefined, undefined);
         await handle.abort();
         expect(db.runTransaction).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
Audit remediation, final theme — the `updateSchema` global-config mutation race. Bumps **1.3.1 → 1.4.0**.

## The bug
A per-call `schema` (`autoSQL`/`autoSQLChunked`/`openStream`) was applied by **mutating the shared `this.config.schema`** and restoring it in a `finally`. On one `Database` instance:
- Concurrent calls with different schemas raced on that shared field → queries ran against the wrong schema, and the save/restore could leave `config.schema` **permanently wrong**.
- `openStream` held the mutation for the **whole stream lifetime** and leaked it if `end()`/`abort()` never ran.

## The fix
Instead of threading `schema` through ~15 builder signatures (invasive), run each schema-scoped operation inside an **`AsyncLocalStorage`** context. `getConfig()` resolves the schema from that context — without mutating the instance — for the operation and everything it `await`s. Concurrent operations are isolated by construction. The stream handle re-establishes its context in `write()`/`end()`/`abort()` (they run in separate async invocations). No builder signatures change.

New public helper: `Database.runWithSchema(schema, fn)`.

## ✅ Tests
Full suite green on live MySQL + Postgres: **40 suites / 439 tests**. New `schema-context.test.ts` proves two concurrent contexts with different schemas stay isolated across awaits and the shared config is never mutated.

## Audit status
This completes the concurrency theme and the autosql audit's actionable items. Remaining tail (lower priority, noted in earlier PRs): schema-history version-race under no-lock, a stale-`pending` sweeper, and cross-process stream-cleanup liveness — each small and independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)