### PR TITLE
Release 1.4.1 — schema-history version-race + dev-tooling reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.4.1] - 2026-07-05
+### 🐛 Bug Fixes (schema history)
+- **Version-race resilience.** `recordMigrationStart` computes `version = MAX(version)+1` against a `UNIQUE(table_name, version)` constraint; without a schema lock, concurrent migrations could collide. It now retries (recomputing the version) on a unique-constraint violation instead of failing the migration.
+- **Stale `pending` sweep.** Orphaned `pending` starts (from crashed runs) older than 1h are best-effort marked `failed` so they don't linger.
+
+### 🔒 Security / tooling
+- Pin the transitive dev dependency `handlebars` to `4.7.9` via `overrides` (high-severity advisory; not shipped in the package). Raise Jest `testTimeout` to 30s for DB integration tests. Add a `test:unit` script (`jest.unit.config.js`) for fast no-DB runs.
+
+---
+
 ## [1.4.0] - 2026-07-05
 ### 🐛 Bug Fixes (concurrency)
 - **Per-call schema is now isolated per operation.** Passing a `schema` to `autoSQL`/`autoSQLChunked`/`openStream` previously mutated the shared `Database` config schema and restored it in a `finally`. Concurrent calls with different schemas on one instance raced on that shared field (queries against the wrong schema; the restore could leave the config permanently wrong), and `openStream` held the mutation for the whole stream lifetime. Each schema-scoped operation now runs inside an `AsyncLocalStorage` context and `getConfig()` resolves the schema from it without mutating the instance, so concurrent operations stay isolated.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  testTimeout: 30000,
   transform: {
     "^.+\\.tsx?$": ["ts-jest", { useESM: true }]
   },

--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -1,0 +1,29 @@
+/**
+ * Jest config for unit tests only — no live database required.
+ * Run the full suite (including integration tests) with `npm test`.
+ */
+const base = require('./jest.config.js');
+
+module.exports = {
+  ...base,
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    'tests/alter-table\\.test\\.ts',
+    'tests/alter-table-complex\\.test\\.ts',
+    'tests/auto-configure\\.test\\.ts',
+    'tests/auto-sql\\.test\\.ts',
+    'tests/check-table-exists\\.test\\.ts',
+    'tests/create-table\\.test\\.ts',
+    'tests/create-table-complex\\.test\\.ts',
+    'tests/database-connection\\.test\\.ts',
+    'tests/database-error-handling\\.test\\.ts',
+    'tests/database-retry\\.test\\.ts',
+    'tests/get-table-metadata\\.test\\.ts',
+    'tests/index-query-builder\\.test\\.ts',
+    'tests/query-validation\\.test\\.ts',
+    'tests/test-split-table\\.test\\.ts',
+    'tests/exponent-column\\.test\\.ts',
+    'tests/schema-history-db\\.test\\.ts',
+    'tests/transaction-atomicity\\.test\\.ts',
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "jest",
+    "test:unit": "jest --config jest.unit.config.js",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "prepublishOnly": "npm run test && npm run build",
@@ -47,6 +48,9 @@
     "mysql2": "^3.14.3",
     "pg": "^8.16.3",
     "ssh2": "^1.16.0"
+  },
+  "overrides": {
+    "handlebars": "4.7.9"
   },
   "bugs": {
     "url": "https://github.com/walterchoi/autosql/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autosql",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "An auto-parser of JSON into SQL.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/helpers/schemaHistory.ts
+++ b/src/helpers/schemaHistory.ts
@@ -77,6 +77,33 @@ export async function bootstrapSchemaHistoryTable(db: Database): Promise<void> {
 // Record start of migration (status = 'pending')
 // Returns the inserted record id.
 // ---------------------------------------------------------------------------
+// A `pending` migration start older than this is treated as orphaned (a crashed run) and
+// swept to `failed`, so it can't linger forever. Comfortably longer than any real migration.
+const STALE_PENDING_MS = 60 * 60 * 1000;
+
+/** Best-effort: mark this table's orphaned `pending` starts (from crashed runs) as failed. */
+async function sweepStalePending(db: Database, table: string): Promise<void> {
+    const ref = historyTableRef(db.getConfig());
+    const dialect = db.getConfig().sqlDialect;
+    const cutoff = new Date(Date.now() - STALE_PENDING_MS);
+    const [s, t] = ref.includes('.') ? ref.split('.') : ['', ref];
+    if (dialect === 'mysql') {
+        const tableRef = s ? `\`${s}\`.\`${t}\`` : `\`${t}\``;
+        await db.runQuery({
+            query: `UPDATE ${tableRef} SET status = 'failed' WHERE table_name = ? AND status = 'pending' AND applied_at < ?`,
+            params: [table, cutoff.toISOString().slice(0, 19).replace('T', ' ')]
+        }).catch(() => {});
+    } else {
+        const tableRef = s ? `"${s}"."${t}"` : `"${t}"`;
+        await db.runQuery({
+            query: `UPDATE ${tableRef} SET status = 'failed' WHERE table_name = $1 AND status = 'pending' AND applied_at < $2`,
+            params: [table, cutoff.toISOString()]
+        }).catch(() => {});
+    }
+}
+
+const UNIQUE_VIOLATION = /duplicate|unique/i;
+
 export async function recordMigrationStart(
     db: Database,
     table: string,
@@ -86,56 +113,67 @@ export async function recordMigrationStart(
     const ref = historyTableRef(db.getConfig());
     const dialect = db.getConfig().sqlDialect;
     const appliedBy = getAppliedBy();
-    const now = new Date();
 
-    let query: string;
-    if (dialect === 'mysql') {
-        const [s, t] = ref.includes('.') ? ref.split('.') : ['', ref];
-        const tableRef = s ? `\`${s}\`.\`${t}\`` : `\`${t}\``;
-        query = `INSERT INTO ${tableRef} (table_name, version, status, applied_at, applied_by, previous_schema, changes)
+    await sweepStalePending(db, table);
+
+    // The version is computed as MAX(version)+1 against a UNIQUE(table_name, version)
+    // constraint. Without a schema lock, two concurrent migrations can compute the same
+    // version and one hits a unique violation — recompute and retry a few times.
+    const maxAttempts = 5;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const now = new Date();
+        let result: QueryResult;
+        if (dialect === 'mysql') {
+            const [s, t] = ref.includes('.') ? ref.split('.') : ['', ref];
+            const tableRef = s ? `\`${s}\`.\`${t}\`` : `\`${t}\``;
+            const query = `INSERT INTO ${tableRef} (table_name, version, status, applied_at, applied_by, previous_schema, changes)
 SELECT ?, COALESCE(MAX(version), 0) + 1, 'pending', ?, ?, ?, ?
 FROM ${tableRef} WHERE table_name = ?`;
-        // Run the INSERT and LAST_INSERT_ID() in one transaction so they share a single
-        // connection — LAST_INSERT_ID() is connection-scoped, so reading it on a separate
-        // pooled connection (as a second runQuery would) returns 0/unrelated, leaving the
-        // history row stuck at 'pending' and drift detection without a baseline.
-        const result = await db.runTransaction([
-            {
-                query,
-                params: [
-                    table,
-                    now.toISOString().slice(0, 19).replace('T', ' '),
-                    appliedBy,
-                    JSON.stringify(previousSchema),
-                    JSON.stringify(changes),
-                    table
-                ]
-            },
-            { query: 'SELECT LAST_INSERT_ID() AS id', params: [] }
-        ]);
-        return Number(result.results?.[0]?.id ?? 0);
-    } else {
-        const [s, t] = ref.includes('.') ? ref.split('.') : ['', ref];
-        const tableRef = s ? `"${s}"."${t}"` : `"${t}"`;
-        // $1 is used both in the SELECT list and the WHERE clause; without an explicit cast
-        // Postgres infers it as text in one place and varchar in the other and rejects the
-        // statement with "inconsistent types deduced for parameter $1".
-        query = `INSERT INTO ${tableRef} (table_name, version, status, applied_at, applied_by, previous_schema, changes)
+            // Run the INSERT and LAST_INSERT_ID() in one transaction so they share a single
+            // connection — LAST_INSERT_ID() is connection-scoped, so reading it on a separate
+            // pooled connection returns 0/unrelated and leaves the row stuck at 'pending'.
+            result = await db.runTransaction([
+                {
+                    query,
+                    params: [
+                        table,
+                        now.toISOString().slice(0, 19).replace('T', ' '),
+                        appliedBy,
+                        JSON.stringify(previousSchema),
+                        JSON.stringify(changes),
+                        table
+                    ]
+                },
+                { query: 'SELECT LAST_INSERT_ID() AS id', params: [] }
+            ]);
+        } else {
+            const [s, t] = ref.includes('.') ? ref.split('.') : ['', ref];
+            const tableRef = s ? `"${s}"."${t}"` : `"${t}"`;
+            // $1 is used both in the SELECT list and the WHERE clause; without an explicit cast
+            // Postgres infers it as text in one place and varchar in the other and rejects the
+            // statement with "inconsistent types deduced for parameter $1".
+            const query = `INSERT INTO ${tableRef} (table_name, version, status, applied_at, applied_by, previous_schema, changes)
 SELECT $1::varchar, COALESCE(MAX(version), 0) + 1, 'pending', $2, $3, $4::jsonb, $5::jsonb
 FROM ${tableRef} WHERE table_name = $1
 RETURNING id`;
-        const result = await db.runQuery({
-            query,
-            params: [
-                table,
-                now.toISOString(),
-                appliedBy,
-                JSON.stringify(previousSchema),
-                JSON.stringify(changes)
-            ]
-        });
-        return Number(result.results?.[0]?.id ?? 0);
+            result = await db.runQuery({
+                query,
+                params: [
+                    table,
+                    now.toISOString(),
+                    appliedBy,
+                    JSON.stringify(previousSchema),
+                    JSON.stringify(changes)
+                ]
+            });
+        }
+
+        const id = Number(result.results?.[0]?.id ?? 0);
+        if (id > 0) return id;
+        if (attempt < maxAttempts && UNIQUE_VIOLATION.test(result.error ?? '')) continue;
+        return 0;
     }
+    return 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/schema-history-version-race.test.ts
+++ b/tests/schema-history-version-race.test.ts
@@ -1,0 +1,33 @@
+import { recordMigrationStart } from "../src/helpers/schemaHistory";
+
+// recordMigrationStart computes version = MAX(version)+1 against a UNIQUE(table_name, version)
+// constraint. Under concurrency without a schema lock, two migrations can collide on the same
+// version; the loser must recompute and retry rather than fail.
+
+function makeDb(insertResults: { success: boolean; error?: string; results?: any[] }[]) {
+    let call = 0;
+    return {
+        getConfig: () => ({ sqlDialect: "mysql" as const, schema: "s" }),
+        runQuery: jest.fn().mockResolvedValue({ success: true }), // sweepStalePending
+        runTransaction: jest.fn().mockImplementation(() => Promise.resolve(insertResults[call++])),
+    } as any;
+}
+
+describe("schema-history version-race handling", () => {
+    test("retries on a unique-constraint collision and returns the eventual id", async () => {
+        const db = makeDb([
+            { success: false, error: "ER_DUP_ENTRY: Duplicate entry '3' for key 'uq_table_version'" },
+            { success: true, results: [{ id: 7 }] },
+        ]);
+        const id = await recordMigrationStart(db, "t", {}, {});
+        expect(id).toBe(7);
+        expect((db.runTransaction as jest.Mock)).toHaveBeenCalledTimes(2);
+    });
+
+    test("does not retry on a non-collision failure", async () => {
+        const db = makeDb([{ success: false, error: "ER_BAD_FIELD_ERROR: Unknown column" }]);
+        const id = await recordMigrationStart(db, "t", {}, {});
+        expect(id).toBe(0);
+        expect((db.runTransaction as jest.Mock)).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
Audit tail + release prep. Bumps **1.4.0 → 1.4.1**.

## Fixes
- **Schema-history version-race** — `recordMigrationStart` retries on a `UNIQUE(table_name, version)` collision (recomputing the version) instead of failing when concurrent migrations run without a schema lock.
- **Stale `pending` sweep** — orphaned `pending` starts older than 1h are best-effort marked `failed`.

## Dev tooling (reconciles the never-merged 1.1.1 line)
- `overrides.handlebars = 4.7.9` (transitive dev-dep advisory; not shipped).
- Jest `testTimeout` 30s; `test:unit` script + `jest.unit.config.js`.

## ✅ Tests
Full suite green on live MySQL + Postgres: **41 suites / 441 tests**.

## ⚠️ Publish prerequisite (must be done in a clean environment)
This dev box cannot build the native optional-dependency chain (`cpu-features` via `ssh2`), which drops `pg` from the lockfile on any local `npm` write — so **`package-lock.json` was not regenerated here**. Before `npm publish`:
1. In a clean environment: `npm install` (applies the handlebars override, keeps `pg`), then `npm audit` should report 0 vulnerabilities.
2. Merge the open Dependabot PRs (#4 js-yaml, #5 glob) — they update the lockfile in CI's clean env.
3. `npm run db:up && npm test` (green), then `npm publish` (runs `prepublishOnly` = full test + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)